### PR TITLE
README.md: add Travis and Codecov badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.com/gap-packages/BlissInterface.svg?branch=master)](https://travis-ci.com/gap-packages/BlissInterface)
+[![Code Coverage](https://codecov.io/github/gap-packages/BlissInterface/coverage.svg?branch=master&token=)](https://codecov.io/gh/gap-packages/BlissInterface)
+
 # The GAP package BlissInterface
 
 This package provides a low level interface to the software [***bliss:*** A Tool for Computing Automorphism Groups and Canonical Labelings of Graphs](http://www.tcs.hut.fi/Software/bliss/), written by Tommi Junttila and Petteri Kaski. 


### PR DESCRIPTION
This way one can see with a glance at the repository what the build status is, and how high the code coverage.

A preview of how this looks: https://github.com/gap-packages/BlissInterface/tree/mh/README